### PR TITLE
add support for .NET core

### DIFF
--- a/source/NonInvasiveKeyboardHook/NonInvasiveKeyboardHook.sln
+++ b/source/NonInvasiveKeyboardHook/NonInvasiveKeyboardHook.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2006
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30717.126
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NonInvasiveKeyboardHookLibrary", "NonInvasiveKeyboardHookLibrary\NonInvasiveKeyboardHookLibrary.csproj", "{0DF3EABA-2C33-4E77-B2DB-B6D23146EDAB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NonInvasiveKeyboardHookLibrary.Core", "NonInvasiveKeyboardHookLibrary\NonInvasiveKeyboardHookLibrary.Core.csproj", "{297F0377-E0B0-48D7-83EE-C76E06BBA860}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{0DF3EABA-2C33-4E77-B2DB-B6D23146EDAB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0DF3EABA-2C33-4E77-B2DB-B6D23146EDAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0DF3EABA-2C33-4E77-B2DB-B6D23146EDAB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{297F0377-E0B0-48D7-83EE-C76E06BBA860}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{297F0377-E0B0-48D7-83EE-C76E06BBA860}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{297F0377-E0B0-48D7-83EE-C76E06BBA860}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{297F0377-E0B0-48D7-83EE-C76E06BBA860}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/source/NonInvasiveKeyboardHook/NonInvasiveKeyboardHookLibrary/NonInvasiveKeyboardHookLibrary.Core.csproj
+++ b/source/NonInvasiveKeyboardHook/NonInvasiveKeyboardHookLibrary/NonInvasiveKeyboardHookLibrary.Core.csproj
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+    <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+	<UseWindowsForms>true</UseWindowsForms>
+	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+	<Description>A C# hotkey manager that uses a low level global hook, but allows registering for specific keys to reduce invasion of user privacy.</Description>
+	<PackageProjectUrl>https://github.com/kfirprods/NonInvasiveKeyboardHook</PackageProjectUrl>
+	<RepositoryUrl>https://github.com/kfirprods/NonInvasiveKeyboardHook</RepositoryUrl>
+	<Authors>Kfir Eichenblat</Authors>
+	<Version>2.1.0</Version>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <WarningLevel>5</WarningLevel>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <None Remove="NonInvasiveKeyboardHookLibrary.nuspec" />
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
I have migrated this library to .NET core.
You can open NonInvasiveKeyboardHookLibrary.Core.csproj with the latest VS 2019, then build it, and then upload the NonInvasiveKeyboardHookLibrary.Core.2.1.0.nupkg to Nuget.
If you have any problem with it, please feel free to let me know.
My email is: yangzhongke8@gmail.com