### PR TITLE
build: fix .NET Framework project build

### DIFF
--- a/source/NonInvasiveKeyboardHook/NonInvasiveKeyboardHookLibrary/NonInvasiveKeyboardHookLibrary.csproj
+++ b/source/NonInvasiveKeyboardHook/NonInvasiveKeyboardHookLibrary/NonInvasiveKeyboardHookLibrary.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <ResolveNuGetPackages>false</ResolveNuGetPackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
I was unable to build the .NET Framework project in VS 2022, after a while I managed to solve the problem by adding `<ResolveNuGetPackages>false</ResolveNuGetPackages>` to the `.csproj` file.

I was trying to install the 2.1.1 .NET Framework version with NuGet, but it wasn't working because the uploaded package has the wrong file structure.

Then I cloned and tried to build it on my own, but some conflict between the .NET Core and Framework projects was not letting me do it.

I created a new NuGet package [here](https://www.nuget.org/packages/NonInvasiveKeyboardHookLibrary.Fork/2.1.3) in the meantime correcting the package, if there's any problem I can delete it, just give me a word