### PR TITLE
Added alternativ keycode

### DIFF
--- a/source/NonInvasiveKeyboardHook/NonInvasiveKeyboardHookLibrary/KeyboardHookManager.cs
+++ b/source/NonInvasiveKeyboardHook/NonInvasiveKeyboardHookLibrary/KeyboardHookManager.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
-using System.Windows.Forms;
 
 namespace NonInvasiveKeyboardHookLibrary
 {


### PR DESCRIPTION
In my case i needed some hotkeys that work with Numpad1 and D1 so i added a list of alternativ codes.

Here is an example for using one hotkey that get triggered with Numpad1 or D1.

KeyboardHookManager _globalHotkeysManager = new KeyboardHookManager();

 _globalHotkeysManager.RegisterHotkey(ModifierKeys.Alt, KeyInterop.VirtualKeyFromKey(Key.NumPad1), () => {}, false, new List<int>() { KeyInterop.VirtualKeyFromKey(Key.D1) } );

Now the hotkey gets triggeres with both combinations -> Alt + Numpad1 or Alt + D1
